### PR TITLE
Create the data directory in the newdir script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Luca Bonavita - mindrones.com",
   "version": "0.0.1",
   "scripts": {
-    "newdir": "rm -rf build && mkdir build",
+    "newdir": "rm -rf build data && mkdir build data",
     "devbuild": "npm run newdir && gulp build",
     "prodbuild": "npm run newdir && gulp build --production",
     "dev": "npm run newdir && gulp",


### PR DESCRIPTION
Thank you for this wonderful project! I got a Model 01 a while back and I've yet to start using it seriously, and this will be a great help to get the hang of it quickly.

`npm run devbuild` gives rise to the following error on a fresh install:

```bash
Error: ENOENT: no such file or directory, open 'data/words.json'
```

This PR creates the `data` directory in addition to the `build` directory in the `newdir` script.